### PR TITLE
Fix a very small typo in the english impressum

### DIFF
--- a/app/src/main/assets/impressum/en/impressum.html
+++ b/app/src/main/assets/impressum/en/impressum.html
@@ -72,7 +72,7 @@
     <div class="divider"></div>
 
     <h1>DP3T</h1>
-    <p class="text">The app is based on <strong>DP3T</strong> A project licenced subject to the conditions of the <strong>MPL 2</strong>licence.</p>
+    <p class="text">The app is based on <strong>DP3T</strong> A project licenced subject to the conditions of the <strong>MPL 2</strong> licence.</p>
     <div class="link">
         <img src="../img/ic-link-external.svg">
         <a href="https://www.github.com/DP-3T/">www.github.com/DP-3T</a>


### PR DESCRIPTION
This is just a very small thing I noticed. There is no space behind "MPL 2" and "licence" in the english impressum page.