### PR TITLE
Feature/show next fake request date in log version

### DIFF
--- a/app/src/main/java/ch/admin/bag/dp3t/contacts/HistoryFragment.java
+++ b/app/src/main/java/ch/admin/bag/dp3t/contacts/HistoryFragment.java
@@ -7,11 +7,11 @@
  *
  * SPDX-License-Identifier: MPL-2.0
  */
-
 package ch.admin.bag.dp3t.contacts;
 
 import android.os.Bundle;
 import android.view.View;
+import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
@@ -20,7 +20,11 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
 import ch.admin.bag.dp3t.R;
+import ch.admin.bag.dp3t.storage.SecureStorage;
 import ch.admin.bag.dp3t.viewmodel.TracingViewModel;
 
 public class HistoryFragment extends Fragment {
@@ -51,6 +55,11 @@ public class HistoryFragment extends Fragment {
 		toolbar.setNavigationOnClickListener(v -> getParentFragmentManager().popBackStack());
 
 		setupRecyclerView(view);
+
+		SimpleDateFormat sdf = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss", Locale.GERMAN);
+		TextView nextFakeRequestView = view.findViewById(R.id.history_next_fake_request);
+		nextFakeRequestView.setText(getString(R.string.synchronizations_view_next_fake_request) +
+				sdf.format(SecureStorage.getInstance(view.getContext()).getTDummy()));
 	}
 
 	private void setupRecyclerView(View view) {

--- a/app/src/main/res/layout/fragment_history.xml
+++ b/app/src/main/res/layout/fragment_history.xml
@@ -69,6 +69,29 @@
 				android:text="@string/synchronizations_view_info_answer" />
 
 		</LinearLayout>
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="@dimen/spacing_small"
+			android:orientation="horizontal">
+
+			<ImageView
+				android:layout_width="@dimen/icon_size"
+				android:layout_height="@dimen/icon_size"
+				android:layout_marginRight="@dimen/spacing_medium_large"
+				android:src="@drawable/ic_handshakes"
+				android:tint="@color/blue_main" />
+
+			<TextView
+				android:id="@+id/history_next_fake_request"
+				style="@style/NextStep.Text"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:breakStrategy="high_quality"
+				android:hyphenationFrequency="full"
+				tools:text="Next fake request: 13.10.2020 15:28" />
+
+		</LinearLayout>
 
 	</LinearLayout>
 

--- a/app/src/main/res/values/strings_untranslated.xml
+++ b/app/src/main/res/values/strings_untranslated.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2020 Ubique Innovation AG <https://www.ubique.ch>
   ~
   ~ This Source Code Form is subject to the terms of the Mozilla Public
@@ -10,6 +9,7 @@
   -->
 
 <resources>
+	<string name="synchronizations_view_next_fake_request" translatable="false">"Next fake request: "</string>
 	<string name="synchronizations_view_sync_via_open" translatable="false">"  • Open"</string>
 	<string name="synchronizations_view_sync_via_background" translatable="false">"  • Sync"</string>
 	<string name="synchronizations_view_sync_via_scheduled" translatable="false">"  • Scheduled"</string>


### PR DESCRIPTION
In the Log-Flavor-App the date of the next fake request should be displayed in the synchronisation view for better possibility to analyze/verify the functionality of the app.