### PR TITLE
Fix topmost y-label cut off

### DIFF
--- a/app/src/main/java/ch/admin/bag/dp3t/stats/DiagramYAxisView.java
+++ b/app/src/main/java/ch/admin/bag/dp3t/stats/DiagramYAxisView.java
@@ -31,6 +31,7 @@ public class DiagramYAxisView extends View {
 	private float dp;
 
 	private int maxYValue;
+	private float paddingTopDp;
 
 	private Paint labelPaint;
 	Rect textRect = new Rect();
@@ -55,7 +56,9 @@ public class DiagramYAxisView extends View {
 	private void init(Context context) {
 		dp = context.getResources().getDisplayMetrics().density;
 
-		int labelPaintColor = getResources().getColor(R.color.stats_diagram_labels, null);
+		paddingTopDp = context.getResources().getDimension(R.dimen.stats_diagram_padding_top);
+
+		int labelPaintColor = context.getResources().getColor(R.color.stats_diagram_labels, null);
 		float labelTextSize = context.getResources().getDimension(R.dimen.text_size_small);
 		Typeface labelTypeface = ResourcesCompat.getFont(context, R.font.inter_regular);
 		labelPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
@@ -89,12 +92,16 @@ public class DiagramYAxisView extends View {
 
 	private void drawYAxisLabels(Canvas canvas) {
 		float xAxisYCoord = getHeight() - DiagramView.OFFSET_BOTTOM_X_AXIS * dp;
+		float diagramHeight = xAxisYCoord - paddingTopDp;
 
 		for (int yLabel : getYAxisLabelValues(maxYValue)) {
 			String label = Integer.toString(yLabel);
 
+			// Note that the origin of the text is the BOTTOM LEFT coordinate (not the top left)!!!
 			labelPaint.getTextBounds(label, 0, label.length(), textRect);
-			float bottom = xAxisYCoord + textRect.height() / 2F - xAxisYCoord * (yLabel / (float) maxYValue);
+			float bottom = xAxisYCoord								// baseline
+					+ textRect.height() / 2F						// center text vertically
+					- (yLabel / (float) maxYValue) * diagramHeight;	// move back up according to the y-label value
 
 			canvas.drawText(label, PADDING_Y_AXIS_LEFT * dp, bottom, labelPaint);
 		}

--- a/app/src/main/res/layout/layout_stats_diagram.xml
+++ b/app/src/main/res/layout/layout_stats_diagram.xml
@@ -22,14 +22,14 @@
 		android:id="@+id/diagram_box"
 		android:layout_width="match_parent"
 		android:layout_height="@dimen/stats_diagram_height_minus_margins"
-		android:layout_marginTop="@dimen/stats_diagram_padding_top"
 		android:layout_marginBottom="@dimen/stats_diagram_padding_bottom"
 		android:orientation="horizontal">
 
 		<FrameLayout
 			android:layout_width="0dp"
 			android:layout_height="match_parent"
-			android:layout_weight="1">
+			android:layout_weight="1"
+			android:layout_marginTop="@dimen/stats_diagram_padding_top">
 
 			<ch.admin.bag.dp3t.stats.DiagramView
 				android:id="@+id/diagram_view"
@@ -51,6 +51,8 @@
 			</HorizontalScrollView>
 		</FrameLayout>
 
+		<!-- Top margin is part of drawing. This avoids cases where - when the maximum label -->
+		<!-- is at the very top - the upper half of the label is cut off. -->
 		<ch.admin.bag.dp3t.stats.DiagramYAxisView
 			android:id="@+id/diagram_y_axis_view"
 			android:layout_width="wrap_content"


### PR DESCRIPTION
This fixes cases where the largest y-label was not much larger than the largest y-axis label value, causing the upper part of the topmost axis label being cut off.

Instead of having the padding in XML, we now account for it in the drawing (which works since we know that the padding is always larger than `textsize/2`).