### PR TITLE
Move reported as infected check out of the dialog

### DIFF
--- a/app/src/main/java/ch/admin/bag/dp3t/home/HomeFragment.java
+++ b/app/src/main/java/ch/admin/bag/dp3t/home/HomeFragment.java
@@ -385,14 +385,13 @@ public class HomeFragment extends Fragment {
 			@Override
 			public void onChanged(TracingStatusInterface tracingStatusInterface) {
 				long isolationEndDialogTimestamp = secureStorage.getIsolationEndDialogTimestamp();
-				if (isolationEndDialogTimestamp != -1L && System.currentTimeMillis() > isolationEndDialogTimestamp) {
+				if (isolationEndDialogTimestamp != -1L && System.currentTimeMillis() > isolationEndDialogTimestamp &&
+						tracingStatusInterface.isReportedAsInfected()) {
 					new AlertDialog.Builder(requireContext(), R.style.NextStep_AlertDialogStyle)
 							.setTitle(R.string.homescreen_isolation_ended_popup_title)
 							.setMessage(R.string.homescreen_isolation_ended_popup_text)
 							.setPositiveButton(R.string.answer_yes, (dialog, which) -> {
-								if (tracingStatusInterface.isReportedAsInfected()) {
-									tracingStatusInterface.resetInfectionStatus(getContext());
-								}
+								tracingStatusInterface.resetInfectionStatus(getContext());
 								secureStorage.setIsolationEndDialogTimestamp(-1L);
 							})
 							.setNegativeButton(R.string.answer_no, (dialog, which) -> {


### PR DESCRIPTION
Move reported as infected check out of the dialog to prevent dialog showing in case the timestamp was not reset correctly